### PR TITLE
Fix math bugs in quaternion and vector utilities

### DIFF
--- a/include/BowQuaternion.h
+++ b/include/BowQuaternion.h
@@ -263,11 +263,13 @@ namespace bow {
 			\param q Quaternion to normalize.
 			\return Normalized quaternion to the length of one. 
 		*/
-		inline Quaternion Normalize(const Quaternion& q)
-		{
-			double length = std::sqrt(Dot(q, q));
-			return (1.0 / std::sqrt(Dot(q, q))) * q;
-		}
+               inline Quaternion Normalize(const Quaternion& q)
+               {
+                       double length = std::sqrt(Dot(q, q));
+                       if (length == 0.0)
+                               return q;
+                       return (1.0 / length) * q;
+               }
 
 		//! Matrices here are [row][column], row major.
 		/*!

--- a/include/BowVector4.h
+++ b/include/BowVector4.h
@@ -190,14 +190,14 @@ namespace bow {
 
 	// Cross product calculation for a 3D Vector
 	template <typename T> 
-	inline Vector4<T> CrossP(const Vector4<T>& v1, const Vector4<T>& v2)
-	{
-		return Vector4<T>(
-			v1.y * other.z - v1.z * other.y,
-			v1.z * other.x - v1.x * other.z,
-			v1.x * other.y - v1.y * other.x,
-			1.0f);
-	}
+       inline Vector4<T> CrossP(const Vector4<T>& v1, const Vector4<T>& v2)
+       {
+               return Vector4<T>(
+                       v1.y * v2.z - v1.z * v2.y,
+                       v1.z * v2.x - v1.x * v2.z,
+                       v1.x * v2.y - v1.y * v2.x,
+                       (T)1);
+       }
 
 	template<typename C>
 	inline std::ostream& operator << (std::ostream& str, const Vector4<C>& vec)


### PR DESCRIPTION
## Summary
- fix the cross product function for `Vector4`
- normalize quaternions using a single square root and guard against zero length

## Testing
- `cppcheck include/BowQuaternion.h include/BowVector4.h`

------
https://chatgpt.com/codex/tasks/task_e_684034bca1fc832e8752673e6bc8b95a